### PR TITLE
Adds draft option for project documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use [Portway](https://getportway.com) as a content source for your GatsbyJS site
 
 See the [Guide on building a website using Portway and GatsbyJS](https://docs.portway.app/guides/build-a-simple-website-with-gatsby)
 
-### Setting up the plugin
+## Setting up the plugin
 
 In your gatsby project directory:
 
@@ -12,9 +12,9 @@ In your gatsby project directory:
 
 Then in your project’s gatsby-config.js file add the plugin to the registry, we recommend passing in the necessary Portway token and project id as environment variables, you’ll never want to check your tokens into source control.
 
-Include the gatsby-plugin-sharp and gatsby-transformer-sharp plugins to add options for portway image handling and caching
+Include the `gatsby-plugin-sharp` and `gatsby-transformer-sharp` plugins to add options for portway image handling and caching.
 
-```js
+```javascript
 plugins: [
   gatsby-plugin-sharp,
   gatsby-transformer-sharp,
@@ -28,53 +28,38 @@ plugins: [
 ]
 ```
 
-Here are some Gatsby tips on using environment variables https://www.gatsbyjs.org/docs/environment-variables/https://www.gatsbyjs.org/docs/environment-variables/
+### Options
 
-#### Example query for fetching project data:
+| Option | Required | Description | Default |
+|---|---|---|---|
+| draft |   | If true, will query unpublished documents | false |
+| projectId | * | The project ID from your URL https://portway.app/d/projects/#ID# |   |
+| token | * | The token, or key from your project’s API Keys section |   |
+
+Here are some Gatsby [tips on using environment variables](https://www.gatsbyjs.org/docs/environment-variables/https://www.gatsbyjs.org/docs/environment-variables/).
+
+## Example query for fetching project data:
 
 ```graphql
 export const query = graphql`
   query portwayQuery {
     allPortwayDocument {
       nodes {
-        children {
+        id
+        name
+        slug
+        childrenPortwayField {
           id
-          ... on PortwayField {
-            id
-            name
-            order
-            structuredValue {
-              type
-              tag
-            }
-            type
-            uid
-            updatedAt
-            value
-            versionId
-            createdAt
-            documentId
-          }
+          name
+          value
+          versionId
+          createdAt
+          order
+          type
+          updatedAt
         }
-        lastPublishedAt
-        projectId
-        publishedVersionId
-        uid
         updatedAt
-        name
-        id
         createdAt
-      }
-    }
-    allPortwayProject {
-      nodes {
-        createdAt
-        createdBy
-        id
-        description
-        name
-        uid
-        updatedAt
       }
     }
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -52,7 +52,6 @@ const fetchProject = async (projectId, token) => {
 const fetchProjectDocuments = async (projectId, draft, token) => {
   let documents
   const draftPram = draft === 'true' ? '?draft=true' : ''
-  console.log(`https://api.portway.app/api/v1/projects/${projectId}/documents${draftPram}`)
 
   try {
     const { data } = await fetchFromPortway(
@@ -70,7 +69,6 @@ const fetchProjectDocuments = async (projectId, draft, token) => {
 const fetchDocumentFields = async (documentId, draft, token) => {
   let fields
   const draftPram = draft === 'true' ? '?draft=true' : ''
-  console.log(`https://api.portway.app/api/v1/documents/${documentId}/fields${draftPram}`)
 
   try {
     const { data } = await fetchFromPortway(
@@ -129,9 +127,7 @@ exports.sourceNodes = async ({
   const { draft, projectId, token } = configOptions
 
   if (draft === 'true') {
-    console.warn('-----------------------------------')
-    console.warn('     Portway is in Draft mode!     ')
-    console.warn('-----------------------------------')
+    console.warn('🚨 Portway is in Draft mode!')
   }
 
   const project = await fetchProject(projectId, token)
@@ -202,4 +198,4 @@ exports.sourceNodes = async ({
   return
 }
 
-exports.onPreInit = () => console.log('Loaded gatsby-source-portway')
+exports.onPreInit = () => console.info('Loaded gatsby-source-portway')

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -21,7 +21,7 @@ const fetchFromPortway = async (url, token) => {
       Authorization: `Bearer ${token}`,
     }
   })
-  
+
   if (response.ok) {
     // response.status >= 200 && response.status < 300
     return response.json()
@@ -40,7 +40,7 @@ const fetchProject = async (projectId, token) => {
     )
     project = data
   } catch(err) {
-    throw new Error(`Unable to fetch project with id ${projectId}. 
+    throw new Error(`Unable to fetch project with id ${projectId}.
     Make sure you have the correct project id and that you have access to this project with the token provided.
     Go here to see your Portway project: https://portway.app/d/project/${projectId}
     `)
@@ -49,12 +49,12 @@ const fetchProject = async (projectId, token) => {
   return project
 }
 
-const fetchProjectDocuments = async (projectId, token) => {
+const fetchProjectDocuments = async (projectId, draft, token) => {
   let documents
-
+  const draftPram = draft ? '?draft=true' : ''
   try {
     const { data } = await fetchFromPortway(
-      `https://api.portway.app/api/v1/projects/${projectId}/documents`,
+      `https://api.portway.app/api/v1/projects/${projectId}/documents/${draftPram}`,
       token
     )
     documents = data
@@ -122,7 +122,7 @@ exports.sourceNodes = async ({
   getNodesByType,
 }, configOptions) => {
   const { createNode } = actions
-  const { projectId, token } = configOptions
+  const { draft, projectId, token } = configOptions
 
   const project = await fetchProject(projectId, token)
   // create project node
@@ -143,7 +143,7 @@ exports.sourceNodes = async ({
   }
   createNode(nodeData)
 
-  const projectDocuments = await fetchProjectDocuments(projectId, token)
+  const projectDocuments = await fetchProjectDocuments(projectId, draft, token)
   // loop through documents and create Gatsby nodes
   await Promise.all(
     projectDocuments.map(async (document) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -65,12 +65,13 @@ const fetchProjectDocuments = async (projectId, draft, token) => {
   return documents
 }
 
-const fetchDocumentFields = async (documentId, token) => {
+const fetchDocumentFields = async (documentId, draft, token) => {
   let fields
+  const draftPram = draft === 'true' ? '?draft=true' : ''
 
   try {
     const { data } = await fetchFromPortway(
-      `https://api.portway.app/api/v1/documents/${documentId}/fields`,
+      `https://api.portway.app/api/v1/documents/${documentId}/fields/${draftPram}`,
       token
     )
     fields = data
@@ -125,9 +126,9 @@ exports.sourceNodes = async ({
   const { draft, projectId, token } = configOptions
 
   if (draft === 'true') {
-    console.info('-----------------------------------')
-    console.info('Portway is in Draft mode!')
-    console.info('-----------------------------------')
+    console.warn('-----------------------------------')
+    console.warn('     Portway is in Draft mode!     ')
+    console.warn('-----------------------------------')
   }
 
   const project = await fetchProject(projectId, token)
@@ -155,7 +156,7 @@ exports.sourceNodes = async ({
     projectDocuments.map(async (document) => {
       const documentNodeId = createNodeId(`portway-document-${document.id}`)
 
-      const documentFields = await fetchDocumentFields(document.id, token)
+      const documentFields = await fetchDocumentFields(document.id, draft, token)
 
       // create field nodes
       const documentFieldNodeIds = documentFields.map((field) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -54,7 +54,7 @@ const fetchProjectDocuments = async (projectId, draft, token) => {
   const draftPram = draft === 'true' ? '?draft=true' : ''
   try {
     const { data } = await fetchFromPortway(
-      `https://api.portway.app/api/v1/projects/${projectId}/documents/${draftPram}`,
+      `https://api.portway.app/api/v1/projects/${projectId}/documents${draftPram}`,
       token
     )
     documents = data
@@ -71,7 +71,7 @@ const fetchDocumentFields = async (documentId, draft, token) => {
 
   try {
     const { data } = await fetchFromPortway(
-      `https://api.portway.app/api/v1/documents/${documentId}/fields/${draftPram}`,
+      `https://api.portway.app/api/v1/documents/${documentId}/fields${draftPram}`,
       token
     )
     fields = data

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -51,7 +51,7 @@ const fetchProject = async (projectId, token) => {
 
 const fetchProjectDocuments = async (projectId, draft, token) => {
   let documents
-  const draftPram = draft === 'true' ? '?draft=true' : ''
+  const draftPram = draft.toLowerCase() === 'true' ? '?draft=true' : ''
 
   try {
     const { data } = await fetchFromPortway(
@@ -68,7 +68,7 @@ const fetchProjectDocuments = async (projectId, draft, token) => {
 
 const fetchDocumentFields = async (documentId, draft, token) => {
   let fields
-  const draftPram = draft === 'true' ? '?draft=true' : ''
+  const draftPram = draft.toLowerCase() === 'true' ? '?draft=true' : ''
 
   try {
     const { data } = await fetchFromPortway(
@@ -126,7 +126,7 @@ exports.sourceNodes = async ({
   const { createNode } = actions
   const { draft, projectId, token } = configOptions
 
-  if (draft === 'true') {
+  if (draft.toLowerCase() === 'true') {
     console.warn('🚨 Portway is in Draft mode!')
   }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -51,7 +51,7 @@ const fetchProject = async (projectId, token) => {
 
 const fetchProjectDocuments = async (projectId, draft, token) => {
   let documents
-  const draftPram = draft ? '?draft=true' : ''
+  const draftPram = draft === 'true' ? '?draft=true' : ''
   try {
     const { data } = await fetchFromPortway(
       `https://api.portway.app/api/v1/projects/${projectId}/documents/${draftPram}`,
@@ -123,6 +123,12 @@ exports.sourceNodes = async ({
 }, configOptions) => {
   const { createNode } = actions
   const { draft, projectId, token } = configOptions
+
+  if (draft === 'true') {
+    console.info('-----------------------------------')
+    console.info('Portway is in Draft mode!')
+    console.info('-----------------------------------')
+  }
 
   const project = await fetchProject(projectId, token)
   // create project node

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -52,6 +52,8 @@ const fetchProject = async (projectId, token) => {
 const fetchProjectDocuments = async (projectId, draft, token) => {
   let documents
   const draftPram = draft === 'true' ? '?draft=true' : ''
+  console.log(`https://api.portway.app/api/v1/projects/${projectId}/documents${draftPram}`)
+
   try {
     const { data } = await fetchFromPortway(
       `https://api.portway.app/api/v1/projects/${projectId}/documents${draftPram}`,
@@ -68,6 +70,7 @@ const fetchProjectDocuments = async (projectId, draft, token) => {
 const fetchDocumentFields = async (documentId, draft, token) => {
   let fields
   const draftPram = draft === 'true' ? '?draft=true' : ''
+  console.log(`https://api.portway.app/api/v1/documents/${documentId}/fields${draftPram}`)
 
   try {
     const { data } = await fetchFromPortway(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@portway/gatsby-source-portway",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A portway data fetching plugin for gatsby",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using the following config, Portway will return unpublished documents to Gatsby. Good for local testing before publishing something.

```
{
    resolve: '@portway/gatsby-source-portway',
    options: {
      draft: true,
      token: process.env.PORTWAY_TOKEN,
      projectId: process.env.PORTWAY_PROJECT_ID
    }
  }
```